### PR TITLE
Fixes RAGuide game title

### DIFF
--- a/_issues/2021-09/guide.md
+++ b/_issues/2021-09/guide.md
@@ -3,7 +3,7 @@ issue: 2021-09
 order: 202109-30
 layout: article
 category: RAGuide
-title: "Karate Kid (Atari 2600)"
+title: "Karate (Atari 2600)"
 author: Schlim
 toc: true
 toc_float: true

--- a/_issues/2021-09/index.md
+++ b/_issues/2021-09/index.md
@@ -85,7 +85,7 @@ Community members talking about their favorite sets and why you should play them
 
 #### RAGuide
 
-This month our official RAGuide Curator {% rauser ViperZang %} picked guide from {% rauser Schlim %}. It'll show you kids how to wax on, wax off in Karate Kid (Atari 2600).
+This month our official RAGuide Curator {% rauser ViperZang %} picked guide from {% rauser Schlim %}. It'll show you kids how to defend yourselves in Karate (Atari 2600).
 
 
 #### Current Events


### PR DESCRIPTION
The game is called `Karate` not `Karate Kid`

IDK how to GitHub, so not sure what's up the last lines. I edited the the markdown file on web if that means anything.