### PR TITLE
Fix year in Top 25 awarded achievements for 2026

### DIFF
--- a/_issues/2026-02/monthly-stats.md
+++ b/_issues/2026-02/monthly-stats.md
@@ -296,8 +296,8 @@ Check out which event achievements were earned the most this month. Limit one ac
 
 \* Hardcore only
 
-## Top 25 Awarded 2025 Achievements <!-- 16-2 -->
-Check out which achievements created in 2025 were earned the most this month. Limit one achievement per game.
+## Top 25 Awarded 2026 Achievements <!-- 16-2 -->
+Check out which achievements created in 2026 were earned the most this month. Limit one achievement per game.
 
 | Rank | Achievement                                                       | Game                                                                                 | Times Awarded |
 | :--- | :---------------------------------------------------------------- | :----------------------------------------------------------------------------------- | :------------ |

--- a/_issues/2026-03/monthly-stats.md
+++ b/_issues/2026-03/monthly-stats.md
@@ -304,8 +304,8 @@ Check out which event achievements were earned the most this month. Limit one ac
 
 \* Hardcore only
 
-## Top 25 Awarded 2025 Achievements <!-- 16-2 -->
-Check out which achievements created in 2025 were earned the most this month. Limit one achievement per game.
+## Top 25 Awarded 2026 Achievements <!-- 16-2 -->
+Check out which achievements created in 2026 were earned the most this month. Limit one achievement per game.
 
 | Rank | Achievement                                                                       | Game                                                                                 | Times Awarded |
 | :--- | :-------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------- | :------------ |

--- a/_issues/2026-04/monthly-stats.md
+++ b/_issues/2026-04/monthly-stats.md
@@ -298,8 +298,8 @@ Check out which event achievements were earned the most this month. Limit one ac
 
 \* Hardcore only
 
-## Top 25 Awarded 2025 Achievements <!-- 16-2 -->
-Check out which achievements created in 2025 were earned the most this month. Limit one achievement per game.
+## Top 25 Awarded 2026 Achievements <!-- 16-2 -->
+Check out which achievements created in 2026 were earned the most this month. Limit one achievement per game.
 
 | Rank | Achievement                                                                                | Game                                                                                             | Times Awarded |
 | :--- | :----------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------- | :------------ |


### PR DESCRIPTION
Fixes the year displayed in the "Top 25 Awarded 20XX Achievements" section of monthly stats for February, March and April 2026 issues, which are still referring to 2025:
<img width="1445" height="496" alt="image" src="https://github.com/user-attachments/assets/f735dcf5-da35-44f2-ad7c-c8152c5a6bfc" />

I think the table of content is automatically generated from the header, so all should be good on that end?

Whatever script is being used to generate the page probably needs to be updated as well, but I couldn't find it in the repo